### PR TITLE
feat(proxy): Add TRUST_PROXY environment variable to enable trust proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,14 @@ sudo apt-get install imagemagick
 ```
 __Step 3 (Optional):__ Edit the example files in the _/auth_ folder with your credentials and rename them according to
 the instructions inside the files. You can still run the app without doing this, but certain functions will be missing.
+
+## Running behind a load balancer
+
+If you are running Pasteboard behind a loadbalancer, you should add the following environment variables:
+
+```bash
+NODE_ENV: production
+TRUST_PROXY: loopback, linklocal, 123.123.123.123
+```
+
+See https://expressjs.com/en/guide/behind-proxies.html for more information about proxies.

--- a/config/environments.coffee
+++ b/config/environments.coffee
@@ -45,6 +45,8 @@ exports.init = (app, express) ->
     app.set "views", "#{__dirname}/../views"
     app.set "view engine", "ejs"
 
+    app.set "trust proxy", process.env.TRUST_PROXY if process.env.TRUST_PROXY
+
   # Development
   app.configure "development", ->
     # Use


### PR DESCRIPTION
Thanks for your work on Pasteboard.
We are using Pasteboard behind a HTTPS offloading loadbalancer and we had an issue to display images.

# Actual Behavior

We have the following HTTP/HTTPS mixed content error in Javascript console after image upload:

```
Mixed Content: The page at 'https://img.domain.dev/1gNQxqQt.png' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://img.domain.dev/storage/1gNQxqQt.png'. This request has been blocked; the content must be served over HTTPS.
```

# Expected Behavior

Uploaded images, 

# Steps to Reproduce the Problem

1. Deploy Pasteboard

1. Deploy an HTTPS loadbalancer in front of Pasteboard

1. Upload an image and click on "go to image"

Image should is not display.

# Proposition

I add `TRUST_PROXY` environment variable to configure ExpressJS `trust proxy` parameter (see https://expressjs.com/en/guide/behind-proxies.html).

So we can trust our loadbalancers and use Pasteboard with HTTPS.
